### PR TITLE
Update Amazon IVS Player SDK to 1.6.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,5 @@
 platform :ios, '14.0'
 
 target 'MultiplePlayers-SwiftUI' do
-    pod 'AmazonIVSPlayer', '~> 1.4.1'
+    pod 'AmazonIVSPlayer', '~> 1.6.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.4.1)
+  - AmazonIVSPlayer (1.6.0)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (~> 1.4.1)
+  - AmazonIVSPlayer (~> 1.6.0)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: 373604429cac7e1bacdac93f7efdddae8d0c8e2f
+  AmazonIVSPlayer: ffb432b2359faad4d6e91c5c4b9bbe726d42c5af
 
-PODFILE CHECKSUM: 881a5a4e48deb24f47dd22c56516c34b2ccc3956
+PODFILE CHECKSUM: d10fa8e329a43491becf5ac30e80bd5c1b794fd2
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
Update Amazon IVS Player SDK to 1.6.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
