### PR TITLE
Update Amazon IVS Player SDK to 1.8.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,5 @@
 platform :ios, '14.0'
 
 target 'MultiplePlayers-SwiftUI' do
-    pod 'AmazonIVSPlayer', '~> 1.8.0'
+    pod 'AmazonIVSPlayer', '~> 1.8.1'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.8.0)
+  - AmazonIVSPlayer (1.8.1)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (~> 1.8.0)
+  - AmazonIVSPlayer (~> 1.8.1)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: e4f8df3ece5ff03eb8d557242711476730af294d
+  AmazonIVSPlayer: f366e1f62463f653dc1dc4a9e54225230c3c19b9
 
-PODFILE CHECKSUM: c4ea6e3584b3fe14a6e6c45fc61b654165f3684b
+PODFILE CHECKSUM: 37a80e61deb6b5b6495c7802847a5caad593641c
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
Update Amazon IVS Player SDK to 1.8.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
