### PR TITLE
Update Amazon IVS Player SDK to 1.13.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,5 @@
 platform :ios, '14.0'
 
 target 'MultiplePlayers-SwiftUI' do
-    pod 'AmazonIVSPlayer', '~> 1.8.3'
+    pod 'AmazonIVSPlayer', '~> 1.13.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.8.3)
+  - AmazonIVSPlayer (1.13.0)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (~> 1.8.3)
+  - AmazonIVSPlayer (~> 1.13.0)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: ce792b427a4fe466d6ea32b3ce8abe391d9242d0
+  AmazonIVSPlayer: 3c774902428c0893004c59c7bbf9065cc542327c
 
-PODFILE CHECKSUM: 93b1e742459bc8235d4fa871c8a6dc03a114fa41
+PODFILE CHECKSUM: 2ed50d29c949f9618b31645819f3472cfd7a5e02
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
Update Amazon IVS Player SDK to 1.13.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
