### PR TITLE
Update Amazon IVS Player SDK to 1.20.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,5 @@
 platform :ios, '14.0'
 
 target 'MultiplePlayers-SwiftUI' do
-    pod 'AmazonIVSPlayer', '~> 1.19.0'
+    pod 'AmazonIVSPlayer', '~> 1.20.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.19.0)
+  - AmazonIVSPlayer (1.20.0)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (~> 1.19.0)
+  - AmazonIVSPlayer (~> 1.20.0)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: b9498771b74cd05e93c67dd3844bb4e2c453f2aa
+  AmazonIVSPlayer: 2183a141f179d74251ba041eda22c75cd0f41fc7
 
-PODFILE CHECKSUM: 630492dd96272d7f2718ba9486b5cf56272a655d
+PODFILE CHECKSUM: 69c25e617b4ff615cd515215c05fa5fec386963f
 
 COCOAPODS: 1.12.0


### PR DESCRIPTION
Update Amazon IVS Player SDK to 1.20.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
