### PR TITLE
Update Amazon IVS Player SDK to 1.21.0

### DIFF
--- a/MultiplePlayers-SwiftUI/Helpers.swift
+++ b/MultiplePlayers-SwiftUI/Helpers.swift
@@ -9,17 +9,16 @@ enum MaxQuality: String {
 }
 
 struct IVSPlayerViewWrapper: UIViewRepresentable {
-    let actualView: IVSPlayerView?
+    let playerModel: PlayerModel
 
     func makeUIView(context: Context) -> IVSPlayerView {
-        guard let view = actualView else {
-            return IVSPlayerView()
-        }
-        return view
+        let playerView = IVSPlayerView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        playerView.videoGravity = .resizeAspectFill
+        return playerView
     }
 
     func updateUIView(_ uiView: IVSPlayerView, context: Context) {
-        uiView.setNeedsLayout()
+        uiView.player = playerModel.player
     }
 }
 

--- a/MultiplePlayers-SwiftUI/Models/PlayerModel.swift
+++ b/MultiplePlayers-SwiftUI/Models/PlayerModel.swift
@@ -38,13 +38,9 @@ class PlayerModel: Hashable {
     func play(_ stringUrl: String, maxAllowedQuality: MaxQuality = .high) {
         maxQuality = maxAllowedQuality
         player = IVSPlayer()
-        playerView = IVSPlayerView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
 
         player?.delegate = playerDelegate
         player?.muted = true
-
-        playerView?.player = player
-        playerView?.videoGravity = .resizeAspectFill
 
         if let url = URL(string: stringUrl) {
             player?.load(url)

--- a/MultiplePlayers-SwiftUI/Views/PlayerView.swift
+++ b/MultiplePlayers-SwiftUI/Views/PlayerView.swift
@@ -5,7 +5,7 @@ struct PlayerView: View {
     var playerModel: PlayerModel
 
     var body: some View {
-        IVSPlayerViewWrapper(actualView: playerModel.playerView)
+        IVSPlayerViewWrapper(playerModel: playerModel)
             .background(Color(.sRGB, red: 0.1, green: 0.1, blue: 0.1, opacity: 1))
             .cornerRadius(10)
     }

--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,5 @@
 platform :ios, '14.0'
 
 target 'MultiplePlayers-SwiftUI' do
-    pod 'AmazonIVSPlayer', '~> 1.20.0'
+    pod 'AmazonIVSPlayer', '~> 1.21.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.20.0)
+  - AmazonIVSPlayer (1.21.0)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (~> 1.20.0)
+  - AmazonIVSPlayer (~> 1.21.0)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: 2183a141f179d74251ba041eda22c75cd0f41fc7
+  AmazonIVSPlayer: 85ebbc42536999322ffe5a50de17e850dc6d0a93
 
-PODFILE CHECKSUM: 69c25e617b4ff615cd515215c05fa5fec386963f
+PODFILE CHECKSUM: eedb57e146ba6bca5b971da0dad60118ef3c3986
 
 COCOAPODS: 1.12.0


### PR DESCRIPTION
Update Amazon IVS Player SDK to 1.21.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
